### PR TITLE
add name re-defination and sub-navigators supports

### DIFF
--- a/flask_navigation/api.py
+++ b/flask_navigation/api.py
@@ -23,8 +23,9 @@ class Navigation(object):
 
     ItemReference = ItemReference
 
-    def __init__(self, app=None):
+    def __init__(self, name='nav', app=None):
         self.bars = {}
+        self.name = name
         if app is not None:
             self.init_app(app)
         # connects ext-level signals
@@ -45,7 +46,7 @@ class Navigation(object):
         # connects app-level signals
         appcontext_pushed.connect(self.initialize_bars, app)
         # integrate with jinja template
-        app.add_template_global(self, 'nav')
+        app.add_template_global(self, self.name)
 
     def initialize_bars(self, sender=None, **kwargs):
         """Calls the initializers of all bound navigation bars."""


### PR DESCRIPTION
- If I don't like name `'nav'`, simply pass `name` to `Navigation`.
- Add sub-navigators support. just like this:

``` python
bar1 = nav.Bar('bar1', [
    nav.Item('item1', 'endpoint1'),
    nav.Item('item2', 'endpoint2'),
])
bar2 = nav.Bar('bar2', [
    nav.Item('item3', 'endpoint3', sub_nav_bar=bar1),
    nav.Item('item4', 'endpoint4'),
])
```

then in endpoint1 or endpoint2, item3 will be active.
